### PR TITLE
Bugfix: Ordering of the Postgresql and Icinga2

### DIFF
--- a/manifests/alerting.pp
+++ b/manifests/alerting.pp
@@ -10,7 +10,7 @@ class roles::alerting inherits roles::node {
   -> class { '::profiles::website': }
   -> anchor { 'alerting::end': }
 
-  if defined(Class['profiles::database::postgresql']) and defined(Class['profiles::alerting::icinga2']) {
+  if defined(Class['profiles::database::postgresql']) and defined(Class['profiles::monitoring::icinga2']) {
     Postgresql::Server::Db <||> -> Exec['idopgsql-import-schema']
   }
 


### PR DESCRIPTION
The icinga2 class is defined in profiles::monitoring and not profiles::alerting.
So the following if statement did not match and the ordering line below it never made it into the catalog, making icinga2 trying to import the schema before there even was pgsql on the box.
```
if defined(Class['profiles::database::postgresql']) and defined(Class['profiles::alerting::icinga2']) {
  Postgresql::Server::Db <||> -> Exec['idopgsql-import-schema']
}
```

Signed-off-by: bjanssens <bjanssens@inuits.eu>