### PR TITLE
Allow for postgress to be on a metric-node

### DIFF
--- a/manifests/metrics.pp
+++ b/manifests/metrics.pp
@@ -5,9 +5,14 @@
 #
 class roles::metrics inherits roles::node {
   anchor { 'metrics::begin': }
+  -> class { '::profiles::database': }
   -> class { '::profiles::metrics': }
   -> class { '::profiles::mail': }
   -> class { '::profiles::alerting': }
   -> class { '::profiles::website': }
   -> anchor { 'metrics::end': }
+
+  if defined(Class['profiles::database::postgresql']) and defined(Class['profiles::metrics::graphite_web']) {
+    Postgresql::Server::Db <||> -> Exec['fill postgresql database']
+  }
 }


### PR DESCRIPTION
This commit allows for the creation of a postgresdb on the metric node itself, in this case graphite.
Analog to the alerting role.
Signed-off-by: bjanssens <bjanssens@inuits.eu>